### PR TITLE
Fix postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
     "tracking"
   ],
   "dependencies": {
-    "get-stdin": "~6.0.0",
-    "json-future": "~2.1.2",
-    "lodash": "~4.17.5"
+    "got": "~8.3.1",
+    "json-future": "~2.1.2"
   },
   "devDependencies": {
     "ava": "latest",
@@ -56,7 +55,7 @@
     "clean": "rm -rf node_modules",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "standard-markdown && standard",
-    "postinstall": "curl -sL https://rawgit.com/disconnectme/disconnect-tracking-protection/master/services.json | ./scripts/postinstall",
+    "postinstall": "node scripts/postinstall",
     "precommit": "lint-staged",
     "pretest": "npm run lint",
     "pretty": "prettier-standard index.js {core,test,bin}/**/*.js --single-quote",

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -8,13 +8,27 @@ const got = require('got')
 const DATASET_URL =
   'https://rawgit.com/disconnectme/disconnect-tracking-protection/master/services.json'
 
+
+/**
+The target of `extractDomains` is extract data collections (avoiding other fields)
+from this type of object composition:
+{
+  "Adless": {
+    "https://www.adless.io/": [
+      "adless.io"
+    ],
+    "performance": "true",
+    "cryptominer": "true"
+  }
+}
+**/
 const extractDomains = obj =>
   Object.values(obj).reduce((domains, value) => {
-    if (Object.prototype.toString.call(value) === '[object Object]') return [...domains, ...extractDomains(value)]
     if (Array.isArray(value)) return [...domains, ...value]
+    if (typeof value === "object") return [...domains, ...extractDomains(value)]
     return domains
   }, [])
-  
+
 ;(async () => {
   const { body } = await got(DATASET_URL)
   const { categories } = await jsonFuture.parseAsync(body)
@@ -24,6 +38,6 @@ const extractDomains = obj =>
     return new Set([...set, ...domains])
   }, new Set())
 
-  const sortedDomains = Array.from(domains).sort()
+  const sortedDomains = Array.from(domains).sort() // sorted alphabetically is visually better
   await jsonFuture.saveAsync('domains.json', sortedDomains)
 })()

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -2,25 +2,32 @@
 
 'use strict'
 
-const {reduce, forEach} = require('lodash')
 const jsonFuture = require('json-future')
-const getStdin = require('get-stdin')
+const got = require('got')
+
+const DATASET_URL = 'https://rawgit.com/disconnectme/disconnect-tracking-protection/master/services.json'
+
+const extractDomains = obj => Object.values(obj).reduce((domains, value)=> {
+    if (Object.prototype.toString.call(value) === '[object Object]') {
+      return [ ...domains, ...extractDomains(value)]
+    }
+    if(Array.isArray(value)) {
+      return [...domains, ...value]
+    }
+    return domains
+  }, [])
 
 ;(async () => {
-  const buffer = await getStdin()
-  const {categories: services} = await jsonFuture.parseAsync(buffer)
+  const { body } = await got(DATASET_URL)
+  const { categories } = await jsonFuture.parseAsync(body)
 
-  const domains = Array.from(reduce(services, (set, service) => {
-    forEach(service, company => {
-      forEach(company, domains => {
-        forEach(domains, domain => {
-          set = new Set([...set, ...domain])
-        })
-      })
-    })
+  const domains = Object.values(categories).reduce((set, category) => {
+    const domains = category.reduce(
+      (domains, company) => [...domains, ...extractDomains(company)], []
+    );
+    return new Set([...set, ...domains])
+  }, new Set())
 
-    return set
-  }, new Set()))
-
-  await jsonFuture.saveAsync('domains.json', domains)
+  const sortedDomains = Array.from(domains).sort()
+  await jsonFuture.saveAsync('domains.json', sortedDomains)
 })()

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -5,26 +5,22 @@
 const jsonFuture = require('json-future')
 const got = require('got')
 
-const DATASET_URL = 'https://rawgit.com/disconnectme/disconnect-tracking-protection/master/services.json'
+const DATASET_URL =
+  'https://rawgit.com/disconnectme/disconnect-tracking-protection/master/services.json'
 
-const extractDomains = obj => Object.values(obj).reduce((domains, value)=> {
-    if (Object.prototype.toString.call(value) === '[object Object]') {
-      return [ ...domains, ...extractDomains(value)]
-    }
-    if(Array.isArray(value)) {
-      return [...domains, ...value]
-    }
+const extractDomains = obj =>
+  Object.values(obj).reduce((domains, value) => {
+    if (Object.prototype.toString.call(value) === '[object Object]') return [...domains, ...extractDomains(value)]
+    if (Array.isArray(value)) return [...domains, ...value]
     return domains
   }, [])
-
+  
 ;(async () => {
   const { body } = await got(DATASET_URL)
   const { categories } = await jsonFuture.parseAsync(body)
 
   const domains = Object.values(categories).reduce((set, category) => {
-    const domains = category.reduce(
-      (domains, company) => [...domains, ...extractDomains(company)], []
-    );
+    const domains = category.reduce((domains, company) => [...domains, ...extractDomains(company)], [])
     return new Set([...set, ...domains])
   }, new Set())
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 'use strict'
 
 const jsonFuture = require('json-future')


### PR DESCRIPTION
I was trying to install [browserless](https://browserless.js.org) in Windows, but installation failed me, due to  this package's postinstall script. 
curl is not available by default in Windows and it's not allowed to exec scripts  in this way  `./scripts/postinstall`.

In addition, as weekend kata for me I made faster the denormalization code block.

![benchmark](https://user-images.githubusercontent.com/6113535/41499654-d58d679c-7183-11e8-9991-70790d96d605.PNG)

And, I noticed that the json from disconnectme have some fields with strings like "true" or "eef" and on the result the strings was unfolded. I avoid that.

```javascript
{
 "Adless": {
  "https://www.adless.io/": [
   "adless.io"
  ],
  "performance": "true",
  "cryptominer": "true"
  }
}
```

```javascript
[
(...)
"t",
"r",
"u",
"e"
(...)
]
```
